### PR TITLE
Add entities and models for documents and document sections. Will have to double check full text search capability.

### DIFF
--- a/backend/entities/advising/document_entity.py
+++ b/backend/entities/advising/document_entity.py
@@ -8,14 +8,11 @@ from backend.models.document import DocumentEnum
 class DocumentEntity(EntityBase):
     __tablename__ = "document"
 
-    # Unique ID for the news post
+    # Unique ID for the document
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
     # Title of the document
     title: Mapped[str] = mapped_column(String, nullable=False)
-
-    # Content of the document
-    content: Mapped[str] = mapped_column(String, nullable=False) # Might have to change later based on full text search
 
     # Tsvector for full-text search
     tsv_content: Mapped[str] = mapped_column(
@@ -30,8 +27,6 @@ class DocumentEntity(EntityBase):
         Index('ix_document_tsv_content', tsv_content, postgresql_using='gin'),
     )
 
-    # Type of document
-    type: Mapped[int] = mapped_column(Integer, nullable=False) # Registration guide = 1, FAQ = 2
 
     @classmethod
     def from_model(cls, model: document) -> "DocumentEntity":
@@ -60,7 +55,5 @@ class DocumentEntity(EntityBase):
         """
         return document(
             id=self.id,
-            title=self.title,
-            content=self.content,
-            type=self.type,
+            title=self.title
         )

--- a/backend/entities/advising/document_entity.py
+++ b/backend/entities/advising/document_entity.py
@@ -16,8 +16,6 @@ class DocumentEntity(EntityBase):
     # Title of the document
     title: Mapped[str] = mapped_column(String, nullable=False)
 
-    # Content of the document
-    content: Mapped[str] = mapped_column(String, nullable=False) # Might have to change later based on full text search
 
     # NOTE: This field establishes a one-to-many relationship between the documents and sections table.
     sections: Mapped[list["SectionEntity"]] = relationship(
@@ -61,7 +59,6 @@ class DocumentEntity(EntityBase):
         return DocumentDetails(
             id=self.id,
             title=self.title,
-            content=self.content,
             document_id=self.document_id,
             sections=[section.to_overview_model() for section in self.sections],
         )

--- a/backend/entities/advising/document_entity.py
+++ b/backend/entities/advising/document_entity.py
@@ -4,29 +4,26 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from .entity_base import EntityBase
 from ...models.advising import document
 from backend.models.document import DocumentEnum
+from document_section_entity import SectionEntity
+from ...models.advising.document_details import DocumentDetails
 
 class DocumentEntity(EntityBase):
     __tablename__ = "document"
 
-    # Unique ID for the document
+    # Unique ID for the news post
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
     # Title of the document
     title: Mapped[str] = mapped_column(String, nullable=False)
 
-    # Tsvector for full-text search
-    tsv_content: Mapped[str] = mapped_column(
-        "tsv_content", 
-        type_=String, 
-        index=True,
-        nullable=False,
-    )
+    # Content of the document
+    content: Mapped[str] = mapped_column(String, nullable=False) # Might have to change later based on full text search
 
-    # Create a GIN index on the tsv_content column
-    __table_args__ = (
-        Index('ix_document_tsv_content', tsv_content, postgresql_using='gin'),
+    # NOTE: This field establishes a one-to-many relationship between the documents and sections table.
+    sections: Mapped[list["SectionEntity"]] = relationship(
+        back_populates="document", cascade="all,delete"
     )
-
+   
 
     @classmethod
     def from_model(cls, model: document) -> "DocumentEntity":
@@ -40,11 +37,8 @@ class DocumentEntity(EntityBase):
             DocumentEntity: The entity.
         """
         return cls(
-            id=document.id,
-            title=document.title,
-            content=document.content,
-            tsv_content=func.to_tsvector('english', model.content),
-            type=document.type,
+            id=model.id,
+            title=model.title
         )
     def to_model(self) -> document:
         """
@@ -55,5 +49,20 @@ class DocumentEntity(EntityBase):
         """
         return document(
             id=self.id,
-            title=self.title
+            title=self.title,
         )
+    def to_details_model(self) -> DocumentDetails:
+        """
+        Converts a `DocumentEntity` object into a `DocumentDetails` model object
+
+        Returns:
+            DocumentDetails: `DocumentDetails` object from the entity
+        """
+        return DocumentDetails(
+            id=self.id,
+            title=self.title,
+            content=self.content,
+            document_id=self.document_id,
+            sections=[section.to_overview_model() for section in self.sections],
+        )
+

--- a/backend/entities/advising/document_entity.py
+++ b/backend/entities/advising/document_entity.py
@@ -1,0 +1,52 @@
+from sqlalchemy import Integer, String, Boolean, ForeignKey, DateTime
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .entity_base import EntityBase
+from ...models.advising import document
+from backend.models.document import DocumentEnum
+
+class DocumentEntity(EntityBase):
+    __tablename__ = "document"
+
+    # Unique ID for the news post
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    # Title of the document
+    title: Mapped[str] = mapped_column(String, nullable=False)
+
+    # Content of the document
+    content: Mapped[str] = mapped_column(String, nullable=False) # Might have to change later based on full text search
+
+    # Type of document
+    type: Mapped[int] = mapped_column(Integer, nullable=False) # Registration guide = 1, FAQ = 2
+
+    @classmethod
+    def from_model(cls, model: document) -> "DocumentEntity":
+        """
+        Create a DocumentEntity from a Document model.
+
+        Args:
+            model (Document): The model to create the entity from.
+
+        Returns:
+            DocumentEntity: The entity.
+        """
+        return cls(
+            id=document.id,
+            title=document.title,
+            content=document.content,
+            type=document.type,
+        )
+    def to_model(self) -> document:
+        """
+        Create a Document model from a DocumentEntity.
+
+        Returns:
+            Document: A Document model for API usage.
+        """
+        return document(
+            id=self.id,
+            title=self.title,
+            content=self.content,
+            type=self.type,
+        )

--- a/backend/entities/advising/document_section_entity.py
+++ b/backend/entities/advising/document_section_entity.py
@@ -1,0 +1,54 @@
+from sqlalchemy import Integer, String, Boolean, ForeignKey, DateTime, func, Index
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .entity_base import EntityBase
+from ...models.advising import document
+from backend.models.document import DocumentEnum
+from document_entity import DocumentEntity
+from ...models.advising import document_section
+from ...models.advising.document_section import DocumentSection
+from ...models.advising.document_details import DocumentDetails
+
+class SectionEntity(EntityBase):
+    __tablename__ = "section"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    title: Mapped[str] = mapped_column(String, nullable=False)
+
+    content: Mapped[str] = mapped_column(String, nullable=False)
+
+    # NOTE: This defines a one-to-many relationship between the document and section tables.
+    document_id: Mapped[int] = mapped_column(ForeignKey("document.id"))
+    document: Mapped["DocumentEntity"] = relationship(back_populates="sections")
+
+     # Tsvector for full-text search
+    tsv_content: Mapped[str] = mapped_column(
+        "tsv_content", 
+        type_=String, 
+        index=True,
+        nullable=False,
+    )
+
+    # Create a GIN index on the tsv_content column
+    __table_args__ = (
+        Index('ix_document_tsv_content', tsv_content, postgresql_using='gin'),
+    )
+
+
+    @classmethod
+    def from_model(cls, model: DocumentSection) -> "SectionEntity":
+        return cls(
+            id=model.id,
+            title=model.title,
+            content=model.content,
+            document_id=model.document_id,
+        )
+
+    def to_model(self) -> DocumentSection:
+        return DocumentSection(
+            id=self.id,
+            title=self.title,
+            content=self.content,
+            document_id=self.document_id,
+        )

--- a/backend/models/advising/document.py
+++ b/backend/models/advising/document.py
@@ -1,5 +1,10 @@
 """Pydantic models for the `Document` entity."""
 
+
+__author__ = ["Nathan Kelete"]
+__copyright__ = "Copyright 2023"
+__license__ = "MIT"
+
 from pydantic import BaseModel
 
 class Document(BaseModel):

--- a/backend/models/advising/document.py
+++ b/backend/models/advising/document.py
@@ -1,0 +1,17 @@
+"""Pydantic models for the `Document` entity."""
+
+from pydantic import BaseModel
+from enum import Enum
+
+class DocumentEnum(str, Enum):
+    REGISTRATION_GUIDE = "REGISTRATION GUIDE"
+    FAQ = "FAQ"
+
+class Document(BaseModel):
+    id: int
+    title: str
+    content: str # TODO: Change to full text search / text
+    type: int # Registration guide = 1, FAQ = 2
+    
+    
+

--- a/backend/models/advising/document.py
+++ b/backend/models/advising/document.py
@@ -1,17 +1,10 @@
 """Pydantic models for the `Document` entity."""
 
 from pydantic import BaseModel
-from enum import Enum
-
-class DocumentEnum(str, Enum):
-    REGISTRATION_GUIDE = "REGISTRATION GUIDE"
-    FAQ = "FAQ"
 
 class Document(BaseModel):
     id: int
     title: str
-    content: str # TODO: Change to full text search / text
-    type: int # Registration guide = 1, FAQ = 2
     
     
 

--- a/backend/models/advising/document_details.py
+++ b/backend/models/advising/document_details.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+from .document_section import DocumentSection
+from document import Document
+
+__author__ = ["Nathan Kelete"]
+__copyright__ = "Copyright 2023"
+__license__ = "MIT"
+
+
+class DocumentDetails(Document):
+    """
+    Pydantic model to represent an `Document`, including back-populated
+    relationship fields.
+
+    This model is based on the `DocumentEntity` model, which defines the shape
+    of the `Document` database in the PostgreSQL database.
+    """
+
+    events: list[DocumentSection]

--- a/backend/models/advising/document_details.py
+++ b/backend/models/advising/document_details.py
@@ -16,4 +16,4 @@ class DocumentDetails(Document):
     of the `Document` database in the PostgreSQL database.
     """
 
-    events: list[DocumentSection]
+    sections: list[DocumentSection]

--- a/backend/models/advising/document_section.py
+++ b/backend/models/advising/document_section.py
@@ -1,0 +1,17 @@
+"""Pydantic models for the `Document Section` entity."""
+
+
+__author__ = ["Nathan Kelete"]
+__copyright__ = "Copyright 2023"
+__license__ = "MIT"
+
+from pydantic import BaseModel
+
+class DocumentSection(BaseModel):
+    id: int
+    title: str
+    content: str
+    doc_id: int
+    
+    
+


### PR DESCRIPTION
This PR introduces the DocumentEntity and SectionEntity entities and their respective Pydantic models for managing documents and their sections in the advising module. A one-to-many relationship is established between DocumentEntity and SectionEntity, where each DocumentEntity can have multiple SectionEntity objects.