### PR TITLE
Document/Document Sections Model, Services, Testing Fixes

### DIFF
--- a/backend/entities/academic_advising/document_entity.py
+++ b/backend/entities/academic_advising/document_entity.py
@@ -61,6 +61,6 @@ class DocumentEntity(EntityBase):
         return DocumentDetails(
             id=self.id,
             title=self.title,
-            sections=[section.to_model() for section in self.sections],
+            sections=[section.to_model() for section in self.doc_sections],
         )
 

--- a/backend/entities/academic_advising/document_entity.py
+++ b/backend/entities/academic_advising/document_entity.py
@@ -16,6 +16,8 @@ class DocumentEntity(EntityBase):
     # Title of the document
     title: Mapped[str] = mapped_column(String, nullable=False)
 
+    # link to the document if user needs more than search results
+    link: Mapped[str] = mapped_column(String, nullable=False)
 
     # NOTE: This field establishes a one-to-many relationship between the documents and sections table.
     doc_sections: Mapped[list["DocumentSectionEntity"]] = relationship(
@@ -36,7 +38,8 @@ class DocumentEntity(EntityBase):
         """
         return cls(
             id=model.id,
-            title=model.title
+            title=model.title,
+            link=model.link
         )
     
     def to_model(self) -> Document:
@@ -49,6 +52,7 @@ class DocumentEntity(EntityBase):
         return Document(
             id=self.id,
             title=self.title,
+            link=self.link,
         )
     
     def to_details_model(self) -> DocumentDetails:
@@ -61,6 +65,7 @@ class DocumentEntity(EntityBase):
         return DocumentDetails(
             id=self.id,
             title=self.title,
+            link=self.link,
             sections=[section.to_model() for section in self.doc_sections],
         )
 

--- a/backend/entities/academic_advising/document_section_entity.py
+++ b/backend/entities/academic_advising/document_section_entity.py
@@ -1,11 +1,9 @@
-from sqlalchemy import Integer, String, Boolean, ForeignKey, DateTime, func, Index
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy import Integer, String, Boolean, ForeignKey, DateTime, func, Index, text, event
+from sqlalchemy.orm import Mapped, mapped_column, relationship, mapper
 
 
 from ..entity_base import EntityBase
 from typing import Self
-from ...models.academic_advising import document
-from ...models.academic_advising import document_section
 from sqlalchemy.dialects.postgresql import TSVECTOR
 from ...models.academic_advising.document_section import DocumentSection
 from ...models.academic_advising.document_details import DocumentDetails
@@ -15,25 +13,23 @@ class DocumentSectionEntity(EntityBase):
     __tablename__ = "section"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-
     title: Mapped[str] = mapped_column(String, nullable=False)
-
     content: Mapped[str] = mapped_column(String, nullable=False)
+    tsv_content: Mapped[str] = mapped_column(TSVECTOR, nullable=False)
+
 
     # NOTE: This defines a one-to-many relationship between the document and section tables.
     document_id: Mapped[int] = mapped_column(ForeignKey("document.id"))
     document: Mapped["DocumentEntity"] = relationship(back_populates="doc_sections")
 
-    # Tsvector for full-text search
-    tsv_content: Mapped[str] = mapped_column(
-    type_=TSVECTOR,
-    nullable=False,
-    )
-    
-    # Create a GIN index on the tsv_content column
     __table_args__ = (
-        Index("ix_document_tsv_content", tsv_content, postgresql_using="gin"),
+        Index(
+            "ix_document_section_content_tsv",
+            tsv_content,
+            postgresql_using="gin"
+        ),
     )
+
 
     @classmethod
     def from_model(cls, model: DocumentSection) -> Self:
@@ -42,7 +38,7 @@ class DocumentSectionEntity(EntityBase):
             title=model.title,
             content=model.content,
             document_id=model.document_id,
-        )
+        )  
 
     def to_model(self) -> DocumentSection:
         return DocumentSection(
@@ -51,3 +47,11 @@ class DocumentSectionEntity(EntityBase):
             content=self.content,
             document_id=self.document_id,
         )
+
+# Automatically populate the `tsv_content` column
+@event.listens_for(DocumentSectionEntity, "before_insert")
+@event.listens_for(DocumentSectionEntity, "before_update")
+def update_tsv_content(mapper, connection, target): # type: ignore
+    target.tsv_content = connection.execute(
+        func.to_tsvector(target.content)
+    ).scalar()

--- a/backend/entities/academic_advising/document_section_entity.py
+++ b/backend/entities/academic_advising/document_section_entity.py
@@ -52,6 +52,10 @@ class DocumentSectionEntity(EntityBase):
 @event.listens_for(DocumentSectionEntity, "before_insert")
 @event.listens_for(DocumentSectionEntity, "before_update")
 def update_tsv_content(mapper, connection, target): # type: ignore
-    target.tsv_content = connection.execute(
-        func.to_tsvector(target.content)
+    tsvector_value = connection.execute(
+        text(
+            "SELECT to_tsvector(:content || ' ' || :title)"
+        ),
+        {"content": target.content, "title": target.title}
     ).scalar()
+    target.tsv_content = tsvector_value

--- a/backend/models/academic_advising/document.py
+++ b/backend/models/academic_advising/document.py
@@ -11,6 +11,4 @@ __license__ = "MIT"
 class Document(BaseModel):
     id: int
     title: str
-    
-    
-
+    link: str

--- a/backend/script/reset_demo.py
+++ b/backend/script/reset_demo.py
@@ -15,7 +15,7 @@ import subprocess
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from backend.test.services.academic_advising import drop_in_demo_data
+from backend.test.services.academic_advising import doc_test_data, drop_in_demo_data
 from ..database import engine
 from ..env import getenv
 from .. import entities
@@ -68,6 +68,7 @@ with Session(engine) as session:
     hiring_data.insert_fake_data(session)
     article_data.insert_fake_data(session)
     drop_in_demo_data.insert_fake_data(session)
+    doc_test_data.insert_fake_data(session)
 
     # Commit changes to the database
     session.commit()

--- a/backend/services/academic_advising/document_services.py
+++ b/backend/services/academic_advising/document_services.py
@@ -39,9 +39,8 @@ class DocumentService:
         """
         self.drop_all_documents()
         ## new data will come from API call (markdown_extraction.py)
-        new_data=""
+        new_data = ""
         return self.repopulate_documents(new_data)
-    
 
     def drop_all_documents(self) -> None:
         """Drop and recreate documents table to be repopulated"""
@@ -74,16 +73,17 @@ class DocumentService:
 
         return repopulated_documents
 
-
     def create_document(self, entity_data: dict) -> DocumentDetails:
         """Create a new document with corresponding sections
-        
-            Args: entity_data: A dictionary of parsed data from the API response, each representing an individual document
 
-            Returns:  Pydantic representation of Document
+        Args: entity_data: A dictionary of parsed data from the API response, each representing an individual document
+
+        Returns:  Pydantic representation of Document
         """
         sections_data = entity_data["sections"]
-        new_document = DocumentEntity(title=entity_data["title"], link=entity_data["link"])
+        new_document = DocumentEntity(
+            title=entity_data["title"], link=entity_data["link"]
+        )
 
         self._session.add(new_document)
         self._session.flush()  # Flush ensures `new_document.id` is available
@@ -91,12 +91,12 @@ class DocumentService:
         # Create associated document sections
         for section_data in sections_data:
             section_entity = DocumentSectionEntity(
-                    title=section_data["title"],
-                    content=section_data["content"],
-                    document_id=new_document.id,
-                )
+                title=section_data["title"],
+                content=section_data["content"],
+                document_id=new_document.id,
+            )
             self._session.add(section_entity)
-            self._session.flush() 
+            self._session.flush()
             new_document.doc_sections.append(section_entity)
 
         self._session.add(new_document)
@@ -105,10 +105,10 @@ class DocumentService:
 
     def get_document_by_id(self, id: int) -> DocumentDetails:
         """Retrieve a document by its ID, including its sections.
-        
-            Args: id of the document
 
-            Returns: DocumentDetails: pydantic representation of queried Document
+        Args: id of the document
+
+        Returns: DocumentDetails: pydantic representation of queried Document
         """
         document_query = select(DocumentEntity).where(DocumentEntity.id == id)
         existing_document = self._session.scalars(document_query).one_or_none()
@@ -117,23 +117,27 @@ class DocumentService:
             raise ResourceNotFoundException(f"No document found with matching ID: {id}")
 
         return existing_document.to_details_model()
-    
+
     def get_document_sections(self, document: DocumentEntity) -> list[DocumentSection]:
         """Retrieve all of the sections attached to a document
-        
-            Args:
-                document (DocumentEntity): The document entity whose sections are to be retrieved.
 
-            Returns:
-                list[DocumentSection]: A list of DocumentSection models corresponding to the sections.
+        Args:
+            document (DocumentEntity): The document entity whose sections are to be retrieved.
+
+        Returns:
+            list[DocumentSection]: A list of DocumentSection models corresponding to the sections.
         """
 
         # Query the sections directly via the relationship
-        sections = self._session.query(DocumentSectionEntity).filter_by(document_id=document.id).all()
-    
+        sections = (
+            self._session.query(DocumentSectionEntity)
+            .filter_by(document_id=document.id)
+            .all()
+        )
+
         # Convert entities to models before returning
         return [section.to_model() for section in sections]
-    
+
     def all(self) -> list[DocumentDetails]:
         """Gets all documents from the database"""
         query = select(DocumentEntity).order_by(DocumentEntity.id)
@@ -142,4 +146,30 @@ class DocumentService:
         # Convert entries to a model and return
         return [entity.to_details_model() for entity in entities]
 
+    def search_document_sections(
+        self, search_query: str
+    ) -> list[DocumentSectionEntity]:
+        """
+        Perform a full-text search on the DocumentSectionEntity and return ranked results.
 
+        Args:
+            session (Session): SQLAlchemy session object.
+            search_query (str): The search query string.
+
+        Returns:
+            List[DocumentSectionEntity]: A list of DocumentSectionEntity objects ordered by relevance.
+        """
+        # Create a tsquery from the search string
+        ts_query = func.to_tsquery("english", search_query)
+
+        # Perform the search, rank the results, and return only the entities
+        results = (
+            self._session.query(DocumentSectionEntity)
+            .filter(DocumentSectionEntity.tsv_content.op("@@")(ts_query))
+            .order_by(
+                func.ts_rank_cd(DocumentSectionEntity.tsv_content, ts_query).desc()
+            )
+            .all()
+        )
+
+        return results

--- a/backend/services/academic_advising/document_services.py
+++ b/backend/services/academic_advising/document_services.py
@@ -14,7 +14,7 @@ from ...entities.academic_advising import DocumentEntity, DocumentSectionEntity
 from ...models.academic_advising import DocumentDetails, DocumentSection
 from ...models.academic_advising.document import Document
 
-__authors__ = ["Nathan Kelete"]
+__authors__ = ["Nathan Kelete", "Emmalyn Foster"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
@@ -25,6 +25,23 @@ class DocumentService:
     def __init__(self, session: Session = Depends(db_session)):
         """Initializes the session."""
         self._session = session
+
+    # update when API responses are correctly parsed
+    def refresh_documents(self) -> list[DocumentDetails]:
+        """
+        Drops all existing documents and repopulates the database with new data.
+
+        Args:
+            new_data (list[dict]): List of new document data.
+
+        Returns:
+            list[document.Document]: List of repopulated documents.
+        """
+        self.drop_all_documents()
+        ## new data will come from API call (markdown_extraction.py)
+        new_data=""
+        return self.repopulate_documents(new_data)
+    
 
     def drop_all_documents(self) -> None:
         """Drop and recreate documents table to be repopulated"""
@@ -57,55 +74,72 @@ class DocumentService:
 
         return repopulated_documents
 
-    def refresh_documents(self, new_data: list[dict]) -> list[DocumentDetails]:
-        """
-        Drops all existing documents and repopulates the database with new data.
-
-        Args:
-            new_data (list[dict]): List of new document data.
-
-        Returns:
-            list[document.Document]: List of repopulated documents.
-        """
-        self.drop_all_documents()
-        return self.repopulate_documents(new_data)
 
     def create_document(self, entity_data: dict) -> DocumentDetails:
-        """Create a new document with optional sections."""
+        """Create a new document with corresponding sections
+        
+            Args: entity_data: A dictionary of parsed data from the API response, each representing an individual document
+
+            Returns:  Pydantic representation of Document
+        """
         sections_data = entity_data["sections"]
-        new_document = DocumentEntity.from_model(
-            Document(id=entity_data["id"], title=entity_data["title"])
-        )
+        new_document = DocumentEntity(title=entity_data["title"], link=entity_data["link"])
 
         self._session.add(new_document)
         self._session.flush()  # Flush ensures `new_document.id` is available
 
         # Create associated document sections
         for section_data in sections_data:
-            section_entity = DocumentSectionEntity.from_model(
-                DocumentSection(
-                    id=section_data["id"],
+            section_entity = DocumentSectionEntity(
                     title=section_data["title"],
                     content=section_data["content"],
                     document_id=new_document.id,
                 )
-            )
+            self._session.add(section_entity)
+            self._session.flush() 
             new_document.doc_sections.append(section_entity)
 
-        for section in new_document.doc_sections:
-            print(f"Section ID: {section.id} | TSV Content: {section.tsv_content}")
-
         self._session.add(new_document)
+        self._session.commit()
         return new_document.to_details_model()
 
-    def get_document_by_id(self, entity_id: int) -> DocumentDetails:
-        """Retrieve a document by its ID, including its sections."""
-        document_query = select(DocumentEntity).where(DocumentEntity.id == entity_id)
+    def get_document_by_id(self, id: int) -> DocumentDetails:
+        """Retrieve a document by its ID, including its sections.
+        
+            Args: id of the document
+
+            Returns: DocumentDetails: pydantic representation of queried Document
+        """
+        document_query = select(DocumentEntity).where(DocumentEntity.id == id)
         existing_document = self._session.scalars(document_query).one_or_none()
 
         if not existing_document:
-            raise HTTPException(
-                status_code=404, detail=f"Document with ID {entity_id} not found."
-            )
+            raise ResourceNotFoundException(f"No document found with matching ID: {id}")
 
         return existing_document.to_details_model()
+    
+    def get_document_sections(self, document: DocumentEntity) -> list[DocumentSection]:
+        """Retrieve all of the sections attached to a document
+        
+            Args:
+                document (DocumentEntity): The document entity whose sections are to be retrieved.
+
+            Returns:
+                list[DocumentSection]: A list of DocumentSection models corresponding to the sections.
+        """
+
+        # Query the sections directly via the relationship
+        sections = self._session.query(DocumentSectionEntity).filter_by(document_id=document.id).all()
+    
+        # Convert entities to models before returning
+        return [section.to_model() for section in sections]
+    
+    def all(self) -> list[DocumentDetails]:
+        """Gets all documents from the database"""
+        query = select(DocumentEntity).order_by(DocumentEntity.id)
+        entities = self._session.scalars(query).all()
+
+        # Convert entries to a model and return
+        return [entity.to_details_model() for entity in entities]
+
+

--- a/backend/services/academic_advising/document_services.py
+++ b/backend/services/academic_advising/document_services.py
@@ -100,7 +100,7 @@ class DocumentService:
             new_document.doc_sections.append(section_entity)
 
         self._session.add(new_document)
-        self._session.commit()
+        # self._session.commit()
         return new_document.to_details_model()
 
     def get_document_by_id(self, id: int) -> DocumentDetails:

--- a/backend/services/academic_advising/document_services.py
+++ b/backend/services/academic_advising/document_services.py
@@ -3,20 +3,21 @@ The Document service allows the API to manipulate advising data in the database.
 """
 
 from fastapi import Depends, HTTPException
-from sqlalchemy import select, func, delete
+from sqlalchemy import select, func, delete, text
 from sqlalchemy.orm import Session
 from datetime import datetime
 
 from ...database import db_session
 from ..exceptions import ResourceNotFoundException
 
-from ...entities.academic_advising import document_entity, document_section_entity
-
-from ...models.academic_advising import document, document_details, document_section
+from ...entities.academic_advising import DocumentEntity, DocumentSectionEntity
+from ...models.academic_advising import DocumentDetails, DocumentSection
+from ...models.academic_advising.document import Document
 
 __authors__ = ["Nathan Kelete"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
+
 
 class DocumentService:
     """Service to drop all existing documents and repopulate with new ones."""
@@ -26,14 +27,15 @@ class DocumentService:
         self._session = session
 
     def drop_all_documents(self) -> None:
-        """Delete all existing documents and their sections."""
-        self._session.execute(delete(document_section_entity.DocumentSectionEntity))
-        self._session.execute(delete(document_entity.DocumentEntity))
+        """Drop and recreate documents table to be repopulated"""
+        self._session.execute(text("DROP TABLE IF EXISTS drop_in CASCADE"))
+        self._session.commit()  # Commit the DROP TABLE to finalize it
+
+        # Recreate the table using SQLAlchemy
+        DocumentEntity.__table__.create(self._session.get_bind(), checkfirst=True)
         self._session.commit()
 
-    def repopulate_documents(
-        self, documents_data: list[dict]
-    ) -> list[document.Document]:
+    def repopulate_documents(self, documents_data: list[dict]) -> list[DocumentDetails]:
         """
         Repopulates the document table with new data.
 
@@ -41,46 +43,21 @@ class DocumentService:
             documents_data (list[dict]): A list of dictionaries, each representing a document.
 
         Returns:
-            list[document.Document]: List of inserted documents.
+            list[document.DocumentDetails]: List of inserted documents.
         """
-        # Clear the existing table data
-        self._session.query(document_entity.DocumentEntity).delete()
-        self._session.commit()
 
         # Repopulate with new data
         repopulated_documents = []
         for data in documents_data:
-            # Extract document metadata and sections
-            sections_data = data.pop("sections", [])
-            new_document = document_entity.DocumentEntity.from_model(
-                document.Document(
-                    id=data["id"], title=data["title"], doc_sections=sections_data
-                )
-            )
-
-            # Add sections
-            for section in sections_data:
-                section_entity = (
-                    document_section_entity.DocumentSectionEntity.from_model(
-                        document_section.DocumentSection(
-                            id=section["id"],
-                            title=section["title"],
-                            content=section["content"],
-                        )
-                    )
-                )
-                new_document.sections.append(section_entity)
-
-            # Add the new document to the session
-            self._session.add(new_document)
-            repopulated_documents.append(new_document.to_details_model())
+            new_document = self.create_document(data)
+            repopulated_documents.append(new_document)
 
         # Commit the new data to the database
         self._session.commit()
 
         return repopulated_documents
 
-    def refresh_documents(self, new_data: list[dict]) -> list[document.Document]:
+    def refresh_documents(self, new_data: list[dict]) -> list[DocumentDetails]:
         """
         Drops all existing documents and repopulates the database with new data.
 
@@ -93,96 +70,37 @@ class DocumentService:
         self.drop_all_documents()
         return self.repopulate_documents(new_data)
 
-    def create_document(self, entity_data: dict) -> document.Document:
+    def create_document(self, entity_data: dict) -> DocumentDetails:
         """Create a new document with optional sections."""
-        sections_data = entity_data.pop("sections", [])
-        new_document = document_entity.DocumentEntity.from_model(
-            document.Document(id=entity_data["id"], title=entity_data["title"])
+        sections_data = entity_data["sections"]
+        new_document = DocumentEntity.from_model(
+            Document(id=entity_data["id"], title=entity_data["title"])
         )
+
+        self._session.add(new_document)
+        self._session.flush()  # Flush ensures `new_document.id` is available
 
         # Create associated document sections
         for section_data in sections_data:
-            section_entity = document_section_entity.DocumentSectionEntity.from_model(
-                document_section.DocumentSection(
+            section_entity = DocumentSectionEntity.from_model(
+                DocumentSection(
                     id=section_data["id"],
                     title=section_data["title"],
                     content=section_data["content"],
+                    document_id=new_document.id,
                 )
             )
-            new_document.sections.append(section_entity)
+            new_document.doc_sections.append(section_entity)
+
+        for section in new_document.doc_sections:
+            print(f"Section ID: {section.id} | TSV Content: {section.tsv_content}")
 
         self._session.add(new_document)
-        self._session.commit()
         return new_document.to_details_model()
 
-    def update_document(
-        self, entity_id: int, updated_data: document.Document
-    ) -> document_details.DocumentDetails:
-        """Updates an existing document and its sections.
-
-        Args:
-            entity_id (int): The ID of the document to update.
-            updated_data (document.Document): The updated document data.
-
-        Returns:
-            DocumentDetails: The updated document model.
-
-        Raises:
-            ResourceNotFoundException: If the document is not found.
-        """
-        # Query the document with matching ID
-        obj = self._session.get(document_entity.DocumentEntity, entity_id)
-
-        # Throw ResourceNotFoundException if the document doesn't exist
-        if obj is None:
-            raise ResourceNotFoundException(
-                f"Document does not exist for id {entity_id}"
-            )
-
-        # Update document fields explicitly
-        obj.title = updated_data.title
-        obj.description = updated_data.description
-        obj.created_by = updated_data.created_by
-        obj.last_modified_by = updated_data.last_modified_by
-        obj.creation_date = updated_data.creation_date
-        obj.modification_date = updated_data.modification_date
-
-        # Handle sections if provided
-        if updated_data.sections is not None:
-            # Clear existing sections
-            obj.sections.clear()
-            # Add updated sections
-            for section_data in updated_data.sections:
-                section_entity = (
-                    document_section_entity.DocumentSectionEntity.from_model(
-                        section_data
-                    )
-                )
-                obj.sections.append(section_entity)
-
-        # Save changes
-        self._session.commit()
-
-        # Return updated document details
-        return obj.to_details_model()
-
-    def delete_document(self, entity_id: int) -> None:
-        """Delete a document and its sections."""
-        delete_query = delete(document_entity.DocumentEntity).where(
-            document_entity.DocumentEntity.id == entity_id
-        )
-        result = self._session.execute(delete_query)
-        if result.rowcount == 0:
-            raise HTTPException(
-                status_code=404, detail=f"Document with ID {entity_id} not found."
-            )
-        self._session.commit()
-
-    def get_document_by_id(self, entity_id: int) -> document.Document:
+    def get_document_by_id(self, entity_id: int) -> DocumentDetails:
         """Retrieve a document by its ID, including its sections."""
-        document_query = select(document_entity.DocumentEntity).where(
-            document_entity.DocumentEntity.id == entity_id
-        )
+        document_query = select(DocumentEntity).where(DocumentEntity.id == entity_id)
         existing_document = self._session.scalars(document_query).one_or_none()
 
         if not existing_document:

--- a/backend/services/academic_advising/markdown_extraction.py
+++ b/backend/services/academic_advising/markdown_extraction.py
@@ -1,0 +1,137 @@
+import io
+import re
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from google.oauth2.service_account import Credentials
+
+SERVICE_ACCOUNT_FILE = "csxl-academic-advising-feature.json"
+SCOPES = [
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/documents.readonly",
+]
+
+
+def retrieve_document(file_id: str):
+
+    """
+        Retrieve the markdown format 
+        Args:
+            file_id: the document ID of a single google drive file of MIME type 'application/vnd.google-apps.document'. 
+            This can be found in the route when the document is open and the sharing file link.
+        
+        Returns:
+            An array containing the contents of the file parsed by header exported to markdown formatting. 
+    """
+
+    try:
+        creds = Credentials.from_service_account_file(SERVICE_ACCOUNT_FILE, scopes=SCOPES)
+
+        # creates drive api client
+        service = build("drive", "v3", credentials=creds)
+    
+        return parse_markdown(export_markdown(file_id, service))
+    
+    except HttpError as error:
+        print(f"An error occurred: {error}")
+
+        return None
+
+
+def retrieve_documents(folder_id): # type: ignore
+
+    """
+        Parses through a folder and extracts the data from each file based on MIME types. Accepted MIME types include document and shortcut.
+
+        Args:
+            folder_id: ID of the target Google Drive folder, which can be found in the route/ share link of the folder.
+        
+        Returns:
+
+    """
+
+    creds = Credentials.from_service_account_file(SERVICE_ACCOUNT_FILE, scopes=SCOPES)
+
+    # creates the drive api client
+    service = build("drive", "v3", credentials=creds)
+
+    query = f"'{folder_id}' in parents"
+
+    results = service.files().list(q=query, fields="files").execute()
+    files = results.get("files", [])
+
+    parsed_files = []
+
+    for file in files:
+        mimeType = file.get("mimeType")
+
+        markdown = None
+
+        # Different handlers to extract file id based on MIME type
+        if mimeType == 'application/vnd.google-apps.shortcut':
+            markdown = export_markdown(file['shortcutDetails']['targetId'], service)
+        
+        if mimeType == 'application/vnd.google-apps.document':
+            markdown = export_markdown(file["id"], service)
+
+        if markdown:
+                parsed = parse_markdown(markdown)
+
+                parsed_files += [file["id"], file["name"], parsed]    
+
+
+    return parsed_files
+
+
+def export_markdown(file_id, service): # type: ignore
+    """Download a Document file in markdown format.
+    Args:
+        file_id : file ID of a 'application/vnd.google-apps.document' MIME type file
+        service : drive api client
+    Returns : 
+        the contents of the document in markdown format, as bytes
+
+    Load pre-authorized user credentials from the environment.
+    """
+    try:
+
+        # pylint: disable=maybe-no-member
+        request = service.files().export_media(fileId=file_id, mimeType="text/markdown")
+
+        file = io.BytesIO()
+
+        response = request.execute()
+        file.write(response)
+        file.seek(0)
+
+        markdown_text = file.getvalue().decode("utf-8")
+
+        return markdown_text
+
+    except HttpError as error:
+        print(f"An error occurred: {error}")
+        file = None
+
+    return file.getvalue()
+
+
+def parse_markdown(markdown): # type: ignore
+    """Parse markdown content by extracting headers and their content."""
+
+    pattern = r"^(#{1,6}\s.+?)(?=\n#{1,6}\s|$)(.*?)(?=\n#{1,6}\s|\Z)"
+
+    matches = re.findall(pattern, markdown, re.DOTALL | re.MULTILINE)
+
+    parsed_data = []
+    for header, body in matches:
+        header = header.strip()
+        body = body.strip()
+
+        parsed_data.append([header, body])
+
+    return parsed_data
+
+
+
+#if __name__ == "__main__":
+    #print(retrieve_document("1u3FKLseTbqwg087olUoi7vxImZKZ54EJvzJddWQzNAE"))
+    

--- a/backend/test/services/academic_advising/doc_test.py
+++ b/backend/test/services/academic_advising/doc_test.py
@@ -94,3 +94,15 @@ def test_refresh_documents(document_svc: DocumentService):
         capture_output=True,  # Capture output to check for errors
         text=True,  # Capture output as text
     )
+
+
+def test_search_documents(document_svc: DocumentService):
+    """Test search queries on documents"""
+    results = document_svc.search_document_sections("Introduction")
+    assert len(results) == 1
+
+
+def test_search_documents_general(document_svc: DocumentService):
+    """Test search queries on documents"""
+    results = document_svc.search_document_sections("advising")
+    assert len(results) > 1

--- a/backend/test/services/academic_advising/doc_test.py
+++ b/backend/test/services/academic_advising/doc_test.py
@@ -7,14 +7,13 @@ from backend.services.exceptions import (
     UserPermissionException,
 )
 
+from ..fixtures import document_svc
 from backend.models.academic_advising import DocumentDetails, DocumentSection
 from backend.services.academic_advising.document_services import DocumentService
 
 from .doc_test_data import (
     ENTITY_DATA_CREATE,
     ENTITY_DATA_BASE,
-    ENTITY_DATA_DELETE,
-    ENTITY_DATA_UPDATE,
     fake_data_fixture,
 )
 from . import doc_test_data
@@ -29,10 +28,8 @@ def test_create_document(document_svc: DocumentService):
     """Test creating a new document."""
     # Use ENTITY_DATA_CREATE as test input
     created_document = document_svc.create_document(ENTITY_DATA_CREATE)
-
     # Assert the document was created correctly
     assert created_document.title == ENTITY_DATA_CREATE["title"]
-    assert created_document.description == ENTITY_DATA_CREATE["description"]
     assert len(created_document.sections) == len(ENTITY_DATA_CREATE["sections"])
 
 
@@ -46,35 +43,6 @@ def test_get_document_by_id(document_svc: DocumentService):
     assert fetched_document.id == document_id
     assert fetched_document.title == ENTITY_DATA_BASE["title"]
     assert len(fetched_document.sections) == len(ENTITY_DATA_BASE["sections"])
-
-
-def test_update_document(document_svc: DocumentService):
-    """Test updating an existing document."""
-
-    # Use ENTITY_DATA_UPDATE as test input
-    updated_document = document_svc.update_document(
-        ENTITY_DATA_UPDATE["id"], ENTITY_DATA_UPDATE
-    )
-
-    # Assert the document was updated correctly
-    assert updated_document.title == ENTITY_DATA_UPDATE["title"]
-    assert len(updated_document.sections) == len(ENTITY_DATA_UPDATE["sections"])
-    assert any(
-        section["title"] == "Frequently Asked Questions"
-        for section in ENTITY_DATA_UPDATE["sections"]
-    )
-
-
-def test_delete_document(document_svc: DocumentService):
-    """Test deleting a document."""
-
-    # Delete the document
-    document_id = ENTITY_DATA_DELETE["id"]
-    document_svc.delete_document(document_id)
-
-    # Assert the document no longer exists
-    with pytest.raises(ResourceNotFoundException):
-        document_svc.get_document_by_id(document_id)
 
 
 def test_get_nonexistent_document(document_svc: DocumentService):

--- a/backend/test/services/academic_advising/doc_test.py
+++ b/backend/test/services/academic_advising/doc_test.py
@@ -1,5 +1,6 @@
 """Tests for the Document Services."""
 
+import subprocess
 from unittest.mock import create_autospec
 import pytest
 from backend.services.exceptions import (
@@ -12,43 +13,84 @@ from backend.models.academic_advising import DocumentDetails, DocumentSection
 from backend.services.academic_advising.document_services import DocumentService
 
 from .doc_test_data import (
-    ENTITY_DATA_CREATE,
-    ENTITY_DATA_BASE,
+    DOC_DATA_1,
+    DOC_DATA_2,
+    DOC_TO_CREATE,
     fake_data_fixture,
 )
 from . import doc_test_data
 
 
-__authors__ = ["Nathan Kelete"]
+__authors__ = ["Nathan Kelete", "Emmalyn Foster"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
 
 def test_create_document(document_svc: DocumentService):
     """Test creating a new document."""
-    # Use ENTITY_DATA_CREATE as test input
-    created_document = document_svc.create_document(ENTITY_DATA_CREATE)
+
+    created_document = document_svc.create_document(DOC_TO_CREATE)
+    from_db = document_svc.get_document_by_id(created_document.id)
     # Assert the document was created correctly
-    assert created_document.title == ENTITY_DATA_CREATE["title"]
-    assert len(created_document.sections) == len(ENTITY_DATA_CREATE["sections"])
+    assert created_document.id is not None
+    assert created_document.title == DOC_TO_CREATE["title"]
+    assert len(created_document.sections) == len(DOC_TO_CREATE["sections"])
+    assert from_db is not None
+    assert from_db.id is not None
+    assert from_db.title == created_document.title
+    assert len(from_db.sections) == len(created_document.sections)
 
 
 def test_get_document_by_id(document_svc: DocumentService):
     """Test retrieving a document by its ID."""
-    # Fetch the base document
-    document_id = ENTITY_DATA_BASE["id"]
+    document_id = DOC_DATA_1["id"]
     fetched_document = document_svc.get_document_by_id(document_id)
 
-    # Assert the fetched document matches the base data
     assert fetched_document.id == document_id
-    assert fetched_document.title == ENTITY_DATA_BASE["title"]
-    assert len(fetched_document.sections) == len(ENTITY_DATA_BASE["sections"])
+    assert fetched_document.title == DOC_DATA_1["title"]
+    assert len(fetched_document.sections) == len(DOC_DATA_2["sections"])
+
+
+def test_all(document_svc: DocumentService):
+    """Test getting all documents"""
+    documents = document_svc.all()
+    assert documents is not None
+    assert len(documents) == len(doc_test_data.documents)
 
 
 def test_get_nonexistent_document(document_svc: DocumentService):
     """Test retrieving a non-existent document."""
-
     # Assert that fetching a non-existent document raises an exception
     nonexistent_id = 9999
     with pytest.raises(ResourceNotFoundException):
         document_svc.get_document_by_id(nonexistent_id)
+        pytest.fail()
+
+
+def test_get_document_sections(document_svc: DocumentService):
+    """Test getting the sections associated with a document"""
+    document = document_svc.get_document_by_id(DOC_DATA_1["id"])
+    doc_sections = document_svc.get_document_sections(document)
+
+    assert len(doc_sections) == len(document.sections)
+    assert doc_sections[0].title == document.sections[0].title
+    assert doc_sections[0].id == document.sections[0].id
+
+
+def test_refresh_documents(document_svc: DocumentService):
+    """Tests dropping the Document table and repopulating it on webhook notification to receive all updates"""
+    inserted_documents = document_svc.refresh_documents()
+
+    assert inserted_documents is not None
+    assert len(document_svc.all()) > 0
+
+    # Important to prevent conflicts when testing other services
+    subprocess.run(
+        [
+            "python3",
+            "-m",
+            "backend.script.reset_demo",
+        ],  # Command to reset the database to test data
+        capture_output=True,  # Capture output to check for errors
+        text=True,  # Capture output as text
+    )

--- a/backend/test/services/academic_advising/doc_test_data.py
+++ b/backend/test/services/academic_advising/doc_test_data.py
@@ -12,15 +12,13 @@ from ..reset_table_id_seq import reset_table_id_seq
 DOC_DATA_1 = {
     "id": 1,  # Unique ID for the document
     "title": "Advising Guidelines",
-    "confirmed": True,  # Flag to indicate if the webhook confirmed the data
+    "link": "link",
     "sections": [
         {
-            "id": 101,
             "title": "Introduction",
             "content": "Overview of the advising process.",
         },
         {
-            "id": 102,
             "title": "CS Department Policies",
             "content": "Details on advising specific to the Computer Science department.",
         },
@@ -29,21 +27,31 @@ DOC_DATA_1 = {
 
 DOC_DATA_2 = {
     "id": 2,
-    "title": "New Advising Document",
-    "description": "Details about new advising policies.",
-    "created_by": "staff",
-    "last_modified_by": "staff",
-    "confirmed": True,
+    "title": "Advising Document",
+    "link": "link",
     "sections": [
         {
-            "id": 103,
             "title": "General Policies",
             "content": "Explanation of general advising policies.",
         },
         {
-            "id": 104,
             "title": "Special Cases",
             "content": "Advising information for unique circumstances.",
+        },
+    ]
+}
+
+DOC_TO_CREATE = {
+    "title": "New Advising Document",
+    "link": "link",
+    "sections": [
+        {
+            "title": "Register for COMP 210",
+            "content": "How to register for COMP 210",
+        },
+        {
+            "title": "Register for COMP 590",
+            "content": "How to register for COMP 590",
         },
     ]
 }
@@ -62,15 +70,15 @@ def insert_fake_data(session: Session):
     for document in documents:
         new_document = DocumentEntity(
             id=document["id"],
-            title=document["title"]
+            title=document["title"],
+            link=document["link"]
         )
 
         for section in document["sections"]:
             new_section = DocumentSectionEntity(
-                id=section["id"],
                 title=section["title"],
                 content=section["content"],
-                document_id=new_document["id"],
+                document_id=document["id"],
             )
             new_document.doc_sections.append(new_section)
 

--- a/backend/test/services/academic_advising/doc_test_data.py
+++ b/backend/test/services/academic_advising/doc_test_data.py
@@ -1,11 +1,15 @@
+"""Contains mock data for demo and testing DocumentService"""
+
 import pytest
 from sqlalchemy.orm import Session
 from ....models.academic_advising import DocumentDetails, DocumentSection
 from ....entities.academic_advising import DocumentEntity, DocumentSectionEntity
 from ..reset_table_id_seq import reset_table_id_seq
 
-# Sample data objects
-ENTITY_DATA_BASE = {
+# Sample data from API response, inserted as a document entry into DB
+# It is necessary to use response data instead of creating DocumentSectionEntities directly b/c of tsv_content population
+
+DOC_DATA_1 = {
     "id": 1,  # Unique ID for the document
     "title": "Advising Guidelines",
     "confirmed": True,  # Flag to indicate if the webhook confirmed the data
@@ -23,7 +27,8 @@ ENTITY_DATA_BASE = {
     ],
 }
 
-ENTITY_DATA_CREATE = {
+DOC_DATA_2 = {
+    "id": 2,
     "title": "New Advising Document",
     "description": "Details about new advising policies.",
     "created_by": "staff",
@@ -31,46 +36,22 @@ ENTITY_DATA_CREATE = {
     "confirmed": True,
     "sections": [
         {
+            "id": 103,
             "title": "General Policies",
             "content": "Explanation of general advising policies.",
         },
         {
+            "id": 104,
             "title": "Special Cases",
             "content": "Advising information for unique circumstances.",
         },
-    ],
+    ]
 }
 
-ENTITY_DATA_UPDATE = {
-    "id": 1,
-    "title": "Updated Advising Guidelines",
-    "description": "Revised comprehensive guidelines for academic advising.",
-    "last_modified_by": "advisor",
-    "confirmed": True,
-    "sections": [
-        {
-            "id": 101,
-            "title": "Introduction Updated",
-            "content": "Updated overview of the advising process.",
-        },
-        {
-            "id": 103,  # Adding a new section
-            "title": "Frequently Asked Questions",
-            "content": "Answers to common advising questions.",
-        },
-    ],
-}
-
-ENTITY_DATA_DELETE = {
-    "id": 1,
-    "confirmed": False,  # Indicates the entity should be deleted
-}
 
 documents = [
-    ENTITY_DATA_BASE,
-    ENTITY_DATA_CREATE,
-    ENTITY_DATA_UPDATE,
-    ENTITY_DATA_DELETE,
+    DOC_DATA_1,
+    DOC_DATA_2
 ]
 
 
@@ -78,53 +59,36 @@ def insert_fake_data(session: Session):
     """Inserts fake data into the database for testing."""
 
     # Step 1: Insert the base document with its sections
-    base_document = DocumentEntity(
-        id=ENTITY_DATA_BASE["id"],
-        title=ENTITY_DATA_BASE["title"],
-        confirmed=ENTITY_DATA_BASE["confirmed"],
-    )
-
-    for section in ENTITY_DATA_BASE["sections"]:
-        base_section = DocumentSectionEntity(
-            id=section["id"],
-            title=section["title"],
-            content=section["content"],
-            document_id=ENTITY_DATA_BASE["id"],
+    for document in documents:
+        new_document = DocumentEntity(
+            id=document["id"],
+            title=document["title"]
         )
-        base_document.sections.append(base_section)
 
-    session.add(base_document)
+        for section in document["sections"]:
+            new_section = DocumentSectionEntity(
+                id=section["id"],
+                title=section["title"],
+                content=section["content"],
+                document_id=new_document["id"],
+            )
+            new_document.doc_sections.append(new_section)
 
-    # Step 2: Add the create test document
-    create_document = DocumentEntity(
-        title=ENTITY_DATA_CREATE["title"],
-        description=ENTITY_DATA_CREATE["description"],
-        created_by=ENTITY_DATA_CREATE["created_by"],
-        last_modified_by=ENTITY_DATA_CREATE["last_modified_by"],
-        confirmed=ENTITY_DATA_CREATE["confirmed"],
-    )
-
-    for section in ENTITY_DATA_CREATE["sections"]:
-        create_section = DocumentSectionEntity(
-            title=section["title"],
-            content=section["content"],
-        )
-        create_document.sections.append(create_section)
-
-    session.add(create_document)
+        session.add(new_document)
 
     # Step 4: Reset sequence IDs for consistent test behavior
     reset_table_id_seq(
         session,
         DocumentEntity,
         DocumentEntity.id,
-        ENTITY_DATA_BASE["id"] + len(documents),
+        DOC_DATA_1["id"] + len(documents),
     )
+
     reset_table_id_seq(
         session,
         DocumentSectionEntity,
         DocumentSectionEntity.id,
-        sum(len(doc["sections"]) for doc in [ENTITY_DATA_BASE, ENTITY_DATA_CREATE]) + 1,
+        sum(len(doc["sections"]) for doc in [DOC_DATA_1]) + 1,
     )
 
     # Commit all changes to the database

--- a/backend/test/services/academic_advising/drop_in_demo_data.py
+++ b/backend/test/services/academic_advising/drop_in_demo_data.py
@@ -1,3 +1,5 @@
+"""Contains mock data for demo and testing DropIn Service"""
+
 from datetime import datetime
 import pytest
 import datetime

--- a/backend/test/services/academic_advising/test_responses_api.py
+++ b/backend/test/services/academic_advising/test_responses_api.py
@@ -1,3 +1,5 @@
+"""Contains large Google Calendar API response data for testing"""
+
 from datetime import date, datetime, time
 import datetime
 from sqlalchemy.orm import Session

--- a/backend/test/services/fixtures.py
+++ b/backend/test/services/fixtures.py
@@ -11,7 +11,8 @@ from ...services import (
     EventService,
     RoomService,
     ApplicationService,
-    DropInService
+    DropInService, 
+    DocumentService
 )
 from ...services.academics import HiringService
 from ...services.article import ArticleService

--- a/backend/test/services/fixtures.py
+++ b/backend/test/services/fixtures.py
@@ -87,3 +87,8 @@ def application_svc(session: Session):
 def drop_in_svc(session: Session):
     """DropInService fixture."""
     return DropInService(session)
+
+@pytest.fixture()
+def document_svc(session: Session):
+    """DocumentService Fixture"""
+    return DocumentService(session)


### PR DESCRIPTION
This PR serves as a configuration for the Document and Document Sections functionality. 

## Changes
- The searchable content now includes the content field and title field, and is instantiated when a document entity is created
- Tests for all services are written and passing (excluding the reset_documents() which requires the markdown_extraction.py to be complete)
- Test data was changed to be an expected response after parsing in markdown_extraction.py and are correctly inserted into the database for testing. 
- Full text search service was also added in the Document Service

## Future Considerations
- While other functionality is working, we still need to merge the correct markdown_extraction.py service to properly call the API, parsing the data as expected. Testing with the expected data works, however. 