### PR TITLE
Document Section Markdown Convert to HTML

### DIFF
--- a/backend/services/academic_advising/markdown_extraction.py
+++ b/backend/services/academic_advising/markdown_extraction.py
@@ -48,14 +48,12 @@ def retrieve_documents(folder_id):  # type: ignore
     Returns:
         A list of dictionaries, each representing a document with its metadata and structured sections.
     """
-
     creds = Credentials.from_service_account_file(SERVICE_ACCOUNT_FILE, scopes=SCOPES)
 
     # Creates the Drive API client
     service = build("drive", "v3", credentials=creds)
 
     query = f"'{folder_id}' in parents"
-
     results = service.files().list(q=query, fields="files").execute()
     files = results.get("files", [])
 
@@ -70,8 +68,6 @@ def retrieve_documents(folder_id):  # type: ignore
         if mimeType == "application/vnd.google-apps.shortcut":
             document_id = file["shortcutDetails"]["targetId"]
             markdown = export_markdown(file["shortcutDetails"]["targetId"], service)
-            # handle case for getting and ID from a shortcut
-
         if mimeType == "application/vnd.google-apps.document":
             document_id = file["id"]
             markdown = export_markdown(file["id"], service)
@@ -79,13 +75,18 @@ def retrieve_documents(folder_id):  # type: ignore
         if markdown:
             parsed_sections = parse_markdown(markdown)
 
+            # Filter out sections containing anchors in the body
+            parsed_sections = [
+                section for section in parsed_sections if not contains_anchor_in_content(section[1])
+            ]
+
             # Transform parsed data into the required structure
             structured_data = {
                 "title": file["name"],
                 "link": f"https://docs.google.com/document/d/{document_id}",
                 "sections": [
                     {
-                        "title": section[0].strip(),  # Include header format (e.g., #, ##)
+                        "title": remove_anchor_from_title(section[0]),  # Remove anchor formatting from title
                         "content": section[1].strip(),
                     }
                     for section in parsed_sections
@@ -145,6 +146,15 @@ def parse_markdown(markdown): # type: ignore
         parsed_data.append([header, body])
 
     return parsed_data
+
+
+def contains_anchor_in_content(content: str) -> bool:
+    """Check if the content contains any Markdown anchor references (e.g., {#anchor-id})"""
+    return bool(re.search(r'\[.*\]\(#\S*\)', content))
+
+def remove_anchor_from_title(title: str) -> str:
+    """Remove anchor formatting from title (e.g., {#anchor-id})"""
+    return re.sub(r"{#\S+}", "", title)
 
 
 

--- a/frontend/src/app/advising/advising-search/advising-search.component.html
+++ b/frontend/src/app/advising/advising-search/advising-search.component.html
@@ -19,9 +19,9 @@
           <div *ngIf="searchResults && searchResults.length > 0; else noResults">
             <div *ngFor="let result of searchResults">
               <mat-card appearance="outlined" class="search-result-card">
-                <mat-card-title class="underlined-title">{{ result.title }}</mat-card-title>
+                <mat-card-title class="underlined-title" [innerHTML]="result.title" markdown></mat-card-title>
                 <mat-card-content>
-                  <p>{{ result.content }}</p>
+                  <p [innerHTML]="result.content" markdown></p>
                 </mat-card-content>
               </mat-card>
             </div>
@@ -31,6 +31,4 @@
           </ng-template>
         </mat-card-content>
       </mat-card>
-
-
 </div>

--- a/frontend/src/app/advising/advising-search/advising-search.component.ts
+++ b/frontend/src/app/advising/advising-search/advising-search.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AdvisingService } from '../advising.service';
+import { MarkdownDirective } from 'src/app/shared/directives/markdown.directive';
 
 @Component({
   selector: 'app-advising-search',
@@ -17,21 +18,22 @@ export class AdvisingSearchComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     protected router: Router,
-    public advisingService: AdvisingService, 
+    public advisingService: AdvisingService
   ) {}
 
   ngOnInit(): void {
     this.route.queryParams.subscribe((params) => {
       this.query = params['query'];
       this.searchBarQuery = this.query;
-      // Perform search logic here using the query
       console.log('Search query:', this.query);
       this.performSearch(this.query);
     });
   }
 
   performSearch(query: string): void {
-    this.advisingService.search(query).subscribe((results) => {this.searchResults = results})
+    this.advisingService.search(query).subscribe((results) => {
+      this.searchResults = results;
+    });
   }
 
   /** Handler that runs when the search bar query changes.


### PR DESCRIPTION
All markdown in our document section search should now display correctly as HTML. The markdown_extraction.py was changed to make sure any section titles with anchor were changed to regular titles, as they cannot be anchored in our search results. Sections with content that had anchors were also filtered out, which mostly included the table of contents, which we did not need. 