### PR TITLE
Display Sections by their Document and Link to Google Docs

### DIFF
--- a/frontend/src/app/advising/advising-search/advising-search.component.html
+++ b/frontend/src/app/advising/advising-search/advising-search.component.html
@@ -12,27 +12,38 @@
     </mat-card-content>
 
     <mat-card appearance="outlined" class="advising-search-results">
-        <mat-card-header>
-          <mat-card-title>Results</mat-card-title>
-        </mat-card-header>
-        <mat-card-content>
-          <div *ngIf="searchResults && searchResults.length > 0; else noResults">
-            <div *ngFor="let result of searchResults">
-              <mat-card appearance="outlined" class="search-result-card">
-                <mat-card-title class="underlined-title">
-                  <!-- If you don't use a ?. next the link in the href, the console log will return a type error. 
-                  Regardless of this it still will work either way. Warning in html vs type error in console? *shrug* -->
-                  <a [href]="documentDetailsMap[result.document_id]?.link" [innerHTML]="result.title" markdown></a>
-                  </mat-card-title>
-                <mat-card-content>
-                  <p [innerHTML]="result.content" markdown></p>
-                </mat-card-content>
-              </mat-card>
-            </div>
+      <mat-card-header>
+        <mat-card-title>Results</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <div *ngIf="groupedResults && groupedResultsKeys.length > 0; else noResults">
+          <div *ngFor="let documentId of groupedResultsKeys">
+            <mat-card class="document-group">
+              <mat-card-title class="document-title">
+                <!-- Document title and link -->
+                <a
+                  [href]="documentDetailsMap[+documentId]?.link"
+                  [innerHTML]="documentDetailsMap[+documentId]?.title"
+                  markdown
+                ></a>
+              </mat-card-title>
+              <mat-card-content>
+                <!-- Sections under the document -->
+                <div *ngFor="let section of groupedResults[+documentId]">
+                  <mat-card class="section-card">
+                    <mat-card-title class="underlined-title" [innerHTML]="section.title" markdown></mat-card-title>
+                    <mat-card-content>
+                      <p [innerHTML]="section.content" markdown></p>
+                    </mat-card-content>
+                  </mat-card>
+                </div>
+              </mat-card-content>
+            </mat-card>
           </div>
-          <ng-template #noResults>
-            <p>No results found.</p>
-          </ng-template>
-        </mat-card-content>
-      </mat-card>
+        </div>
+        <ng-template #noResults>
+          <p>No results found.</p>
+        </ng-template>
+      </mat-card-content>
+    </mat-card>    
 </div>


### PR DESCRIPTION
This takes our search results and groups them by the document_id associated with each one. Then we get each document per document_id. Then we display each section by its document, displaying the title and link above the results for each section group. 