### PR TITLE
Establishing credentials in one file, and differentiating between development/deployment.

### DIFF
--- a/backend/services/academic_advising/drop_in.py
+++ b/backend/services/academic_advising/drop_in.py
@@ -25,24 +25,18 @@ from backend.services.exceptions import (
     DropInResponseException,
     UserPermissionException,
 )
+from backend.services.academic_advising.establish_credentials import getcredentials
 
 
 __authors__ = ["Emmalyn Foster"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
-# During testing (outside of stage branch) bring the credentials .json to the root directory, and make sure it is included in the .gitignore
-# SERVICE_ACCOUNT_FILE = "csxl-academic-advising-feature.json"
-
-# For deployment (on stage branch) establish the .json as an environmental variable in the cloudapps deployment and retrieve the credentials from the environement.
-GOOGLE_CREDS = getenv("GOOGLE_CREDS")
-
-# Parse the JSON string into a dictionary
-service_account_info = json.loads(GOOGLE_CREDS)
+SERVICE_ACCOUNT = getcredentials()
 
 # Create the credentials object from the dictionary
 SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
-creds = Credentials.from_service_account_info(service_account_info, scopes=SCOPES)
+creds = Credentials.from_service_account_info(SERVICE_ACCOUNT, scopes=SCOPES)
 
 
 class DropInService:

--- a/backend/services/academic_advising/drop_in_api.py
+++ b/backend/services/academic_advising/drop_in_api.py
@@ -5,6 +5,7 @@ import re
 from googleapiclient.discovery import build
 from google.oauth2.service_account import Credentials
 from backend.env import getenv
+from backend.services.academic_advising.establish_credentials import getcredentials
 
 
 #  python3 -m pip install python-dateutil <-- required dependency
@@ -14,18 +15,11 @@ import urllib
 # grabbing the events from today -> 6 months from now every time the webhook notifies of our reocurring script
 # drop table first
 
-# During testing (outside of stage branch) bring the credentials .json to the root directory, and make sure it is included in the .gitignore
-# SERVICE_ACCOUNT_FILE = "csxl-academic-advising-feature.json"
-
-# For deployment (on stage branch) establish the .json as an environmental variable in the cloudapps deployment and retrieve the credentials from the environement.
-GOOGLE_CREDS = getenv("GOOGLE_CREDS")
-
-# Parse the JSON string into a dictionary
-service_account_info = json.loads(GOOGLE_CREDS)
+SERVICE_ACCOUNT = getcredentials()
 
 # Create the credentials object from the dictionary
 SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
-creds = Credentials.from_service_account_info(service_account_info, scopes=SCOPES)
+creds = Credentials.from_service_account_info(SERVICE_ACCOUNT, scopes=SCOPES)
 
 def get_events(calendar_id, creds):  # type: ignore
     """Calls events().list to retrieve all events within a 6 month range from today to populate database

--- a/backend/services/academic_advising/establish_credentials.py
+++ b/backend/services/academic_advising/establish_credentials.py
@@ -14,7 +14,6 @@ def getcredentials():
 
     ## For deployment (on stage branch) establish the .json as an environmental variable in the cloudapps deployment and retrieve the credentials from the environement.
     
-    creds = getenv("GOOGLE_CREDS")
-    json.load(creds)
+    creds = json.loads(getenv("GOOGLE_CREDS"))
 
     return creds

--- a/backend/services/academic_advising/establish_credentials.py
+++ b/backend/services/academic_advising/establish_credentials.py
@@ -1,0 +1,19 @@
+"""Establishes the source for the google api service account credentials. This will need to be edited manually depending on if the branch is in development or deployment."""
+
+import json
+
+__authors__ = ["Hope Fauble"]
+
+def getcredentials():
+
+    ## During testing (outside of stage branch) bring the credentials .json to the root directory, and make sure it is included in the .gitignore
+    
+    with open("csxl-academic-advising-feature.json") as file:
+        creds = json.load(file)
+
+    ## For deployment (on stage branch) establish the .json as an environmental variable in the cloudapps deployment and retrieve the credentials from the environement.
+    
+    # creds = getenv("GOOGLE_CREDS")
+    # json.load(creds)
+
+    return creds

--- a/backend/services/academic_advising/establish_credentials.py
+++ b/backend/services/academic_advising/establish_credentials.py
@@ -1,6 +1,7 @@
 """Establishes the source for the google api service account credentials. This will need to be edited manually depending on if the branch is in development or deployment."""
 
 import json
+from backend.env import getenv
 
 __authors__ = ["Hope Fauble"]
 
@@ -8,12 +9,12 @@ def getcredentials():
 
     ## During testing (outside of stage branch) bring the credentials .json to the root directory, and make sure it is included in the .gitignore
     
-    with open("csxl-academic-advising-feature.json") as file:
-        creds = json.load(file)
+    # with open("csxl-academic-advising-feature.json") as file:
+    #     creds = json.load(file)
 
     ## For deployment (on stage branch) establish the .json as an environmental variable in the cloudapps deployment and retrieve the credentials from the environement.
     
-    # creds = getenv("GOOGLE_CREDS")
-    # json.load(creds)
+    creds = getenv("GOOGLE_CREDS")
+    json.load(creds)
 
     return creds

--- a/backend/services/academic_advising/webhook_services.py
+++ b/backend/services/academic_advising/webhook_services.py
@@ -10,19 +10,13 @@ from googleapiclient.discovery import build
 import uuid
 from fastapi import Request
 from backend.env import getenv
+from backend.services.academic_advising.establish_credentials import getcredentials
 
 __authors__ = ["Nathan Kelete"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
-# During testing (outside of stage branch) bring the credentials .json to the root directory, and make sure it is included in the .gitignore
-# SERVICE_ACCOUNT_FILE = "csxl-academic-advising-feature.json"
-
-# For deployment (on stage branch) establish the .json as an environmental variable in the cloudapps deployment and retrieve the credentials from the environement.
-GOOGLE_CREDS = getenv("GOOGLE_CREDS")
-
-# Parse the JSON string into a dictionary
-service_account_info = json.loads(GOOGLE_CREDS)
+SERVICE_ACCOUNT = getcredentials()
 
 # Create the credentials object from the dictionary
 SCOPES = [
@@ -34,7 +28,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/calendar.readonly",
 ]
-creds = Credentials.from_service_account_info(service_account_info, scopes=SCOPES)
+creds = Credentials.from_service_account_info(SERVICE_ACCOUNT, scopes=SCOPES)
 
 calendar_id = getenv("GOOGLE_CALENDAR_ID")
 folder_id = getenv("GOOGLE_FOLDER_ID")


### PR DESCRIPTION
There is now only a single file that must be altered in order to change the source of the service account credentials.

There are two cases for the method of retrieving these credentials:
1. in development branches off of stage
2. in the cloudapps deployment

In a development branch, the credentials .json will be in the local root directory, noted in the .gitignore and loaded from filepath.

In deployment, the credentials must be extracted from the environment variable secrets.

To switch between these two methods depending on the branch's needs, the method is commented out manually.